### PR TITLE
Fix misspelling in header

### DIFF
--- a/docs/challenges/how-challenges-work.mdx
+++ b/docs/challenges/how-challenges-work.mdx
@@ -23,7 +23,7 @@ Once you've selected a language, we'll create the git repository for you and pro
 
 Once we receive the test commit and have verified that your repository is setup correctly, you'll automatically proceed to the first stage.
 
-### 2. First Stage Instructionsbi
+### 2. First Stage Instructions
 
 You'll now see instructions for the first stage.
 


### PR DESCRIPTION
Fix the misspelling in the Markdown header. Originally it was `Instructionsbi` and has been updated to `Instructions`.