### PR TITLE
Fix incorrect filename for codecrafters.yml

### DIFF
--- a/docs/challenges/debug-test-failures.mdx
+++ b/docs/challenges/debug-test-failures.mdx
@@ -9,7 +9,7 @@ description: "Running into test failures that are hard to debug? Try these steps
 
 If you don't have debug mode already, turn it on. When debug mode is on, the tester emits verbose logs that can help you better understand what it is doing.
 
-You can enable debug mode by editing the `.codecrafters.yml` file in the root of your repository and pushing a new commit to trigger a build.
+You can enable debug mode by editing the `codecrafters.yml` file in the root of your repository and pushing a new commit to trigger a build.
 
 Here's what test output looks like with debug mode turned off (the default):
 


### PR DESCRIPTION
The build process expects a file called `codecrafters.yml` and will fail with the following error if one is not found:

`Didn't find a codecrafters.yml file in your repository. This is required to run tests.`