### PR TITLE
Fix right margin of Windows logo in installation.mdx

### DIFF
--- a/docs/cli/installation.mdx
+++ b/docs/cli/installation.mdx
@@ -44,7 +44,7 @@ curl https://codecrafters.io/install.sh | sh
 
 <h2>
   <div className={"flex items-center"}>
-    <svg fill="currentColor" className="relative top-[-2px] mr-3" width="20" height="20" viewBox="0 0 24 24"> <path d="M0 12v-8.646l10-1.355v10.001h-10zm11 0h13v-12l-13 1.807v10.193zm-1 1h-10v7.646l10 1.355v-9.001zm1 0v9.194l13 1.806v-11h-13z"></path>
+    <svg fill="currentColor" className="relative top-[-2px] mr-2" width="20" height="20" viewBox="0 0 24 24"> <path d="M0 12v-8.646l10-1.355v10.001h-10zm11 0h13v-12l-13 1.807v10.193zm-1 1h-10v7.646l10 1.355v-9.001zm1 0v9.194l13 1.806v-11h-13z"></path>
     </svg>
 
     <span>Windows</span>


### PR DESCRIPTION
Before:

![image](https://github.com/user-attachments/assets/e8238da6-a847-4a7c-9f68-a23cabc012fa)

After:

![image](https://github.com/user-attachments/assets/0a5343b0-cad9-451b-b593-cc8f0971fb73)
