### PR TITLE
Update section headers from H1 to H2 in language support documentation.

### DIFF
--- a/docs/challenges/language-support/cpp.mdx
+++ b/docs/challenges/language-support/cpp.mdx
@@ -3,7 +3,7 @@ title: "C++"
 description: "Learn how to solve CodeCrafters challenges in C++"
 ---
 
-# Local development
+## Local development
 
 To run the code for your challenge locally, you'll need [vcpkg](https://vcpkg.io/en/) & `make` installed.
 
@@ -21,13 +21,13 @@ cmake --build ./build
 exec ./build/server "$@"
 ```
 
-# File structure
+## File structure
 
 - The files for your solution are placed in the `src/` directory.
 - `src/Main.cpp` contains the `main` function, which is what the test runner executes.
 - `CMakeLists.txt` contains the rules for compiling your program.
 
-# Adding more files
+## Adding more files
 
 You can add more files and directories to `src/`. The test runner will include them when compiling your code.
 
@@ -62,7 +62,7 @@ int main(int argc, char* argv[]) {
 </CodeGroup>
 <Note>The `#pragma once` directive in `src/Foo.hpp` ensures the header file is included only once during compilation.</Note>
 
-# Adding dependencies
+## Adding dependencies
 
 To add a third-party dependency such as the `asio` to a C++ project, follow these steps:
 

--- a/docs/challenges/language-support/csharp.mdx
+++ b/docs/challenges/language-support/csharp.mdx
@@ -3,7 +3,7 @@ title: "C#"
 description: "Learn how to solve CodeCrafters challenges in C#"
 ---
 
-# Local development
+## Local development
 
 To run the code for your challenge locally, you'll need `dotnet` installed. Our test runners use Dotnet 8.0 (as of April 2024).
 
@@ -16,13 +16,13 @@ look something like this:
 exec dotnet run --project . --configuration Release -- "$@"
 ```
 
-# File structure
+## File structure
 
 - The files for your solution are placed in the `src/` directory.
 - `src/Program.cs` contains the `main` function, which is what the test runner executes.
 - The `.csproj` file defines project settings, target frameworks and dependencies.
 
-# Adding more files
+## Adding more files
 
 You can add more files and directories to `src/`. The test runner will include them when compiling your code.
 
@@ -87,7 +87,7 @@ public class Main {
 
 </CodeGroup>
 
-# Adding dependencies
+## Adding dependencies
 
 You can add dependencies to your project by using `dotnet`.
 

--- a/docs/challenges/language-support/go.mdx
+++ b/docs/challenges/language-support/go.mdx
@@ -7,18 +7,18 @@ description: "Learn how to solve CodeCrafters challenges in Go"
   **New to Go?** We recommend checking out [Go by Example](https://gobyexample.com/) to get up to speed.
 </Note>
 
-# Local development
+## Local development
 
 To run the code for your challenge locally, you'll need `go` installed. Our test runners use `go` version `1.19` (as of November 2023).
 
 The script for your challenge (like `./your_bittorrent.sh`) will automatically compile your code using `go build` before executing it.
 
-# File structure
+## File structure
 
 - The files for your solution are placed in the `app/` directory.
 - `app/main.go` contains the `main` function, which is what the test runner executes.
 
-# Adding more files
+## Adding more files
 
 You can add more files and directories to `app/`. The test runner will include them when compiling your code.
 
@@ -72,7 +72,7 @@ fun main() {
 Note that you'll need to update the import statement in `main.go` to use the new package name (Example: `github.com/codecrafters-io/dns-server-starter-go/app/bar`). You'll
 find the first part of the package name in `go.mod`.
 
-# Adding dependencies
+## Adding dependencies
 
 You can add dependencies to your project by adding them to your `go.mod` file. You can use the `go get` command for this.
 

--- a/docs/challenges/language-support/java.mdx
+++ b/docs/challenges/language-support/java.mdx
@@ -3,7 +3,7 @@ title: "Java"
 description: "Learn how to solve CodeCrafters challenges in Java"
 ---
 
-# Local development
+## Local development
 
 To run the code for your challenge locally, you'll need `java` & `mvn` installed. Our test runners use Java 21 (as of November 2023).
 
@@ -19,12 +19,12 @@ exec java -jar /tmp/codecrafters-redis-target/java_redis.jar "$@"
 
 When running tests on our servers, the `mvn` command will only be run once and then commented out. This ensures that each test only runs the `java -jar ...` line.
 
-# File structure
+## File structure
 
 - The files for your solution are placed in the `src/main/java` directory.
 - `src/main/java/Main.java` contains the `main` function, which is what the test runner executes.
 
-# Adding more files
+## Adding more files
 
 You can add more files and directories to `src/main/java`. The test runner will include them when compiling your code.
 
@@ -83,7 +83,7 @@ public class Main {
   Use an IDE like IntelliJ IDEA which will automatically offer to move your file
   to a directory matching the package name.
 </Tip>
-# Adding dependencies
+## Adding dependencies
 
 You can add dependencies to your project by adding them to your `pom.xml` file.
 

--- a/docs/challenges/language-support/javascript.mdx
+++ b/docs/challenges/language-support/javascript.mdx
@@ -3,7 +3,7 @@ title: "JavaScript"
 description: "Learn how to solve CodeCrafters challenges in JavaScript"
 ---
 
-# Local development
+## Local development
 
 To run the code for your challenge locally, you'll need `node` installed. Our test runners use Node 18 (as of April 2024).
 
@@ -16,12 +16,12 @@ look something like this:
 exec node app/main.js "$@"
 ```
 
-# File structure
+## File structure
 
 - The files for your solution are placed in the `app/` directory.
 - `app/main.js` contains the `main()` function, which is what the test runner executes.
 
-# Adding more files
+## Adding more files
 
 You can add more files and directories to `app/`. The test runner will include them when compiling your code.
 
@@ -53,7 +53,7 @@ function main() {
 
 <Note>We use the CommonJS syntax for importing and exporting of modules.</Note>
 
-# Adding dependencies
+## Adding dependencies
 
 You can add dependencies to your project using `npm`.
 

--- a/docs/challenges/language-support/kotlin.mdx
+++ b/docs/challenges/language-support/kotlin.mdx
@@ -8,18 +8,18 @@ description: "Learn how to solve CodeCrafters challenges in Kotlin"
   Koans](https://play.kotlinlang.org/koans/overview) to get up to speed.
 </Note>
 
-# Local development
+## Local development
 
 To run the code for your challenge locally, you'll need `mvn` installed. Our test runners use `mvn` version `3.9.5` (as of November 2023).
 
 The script for your challenge (like `./your_bittorrent.sh`) will automatically compile your code using `mvn package` before executing it.
 
-# File structure
+## File structure
 
 - The files for your solution are placed in the `src/main/kotlin` directory.
 - `src/main/kotlin/Main.kt` contains the `main` function, which is what the test runner executes.
 
-# Adding more files
+## Adding more files
 
 You can add more files and directories to `src/main/kotlin`. The test runner will include them when compiling your code.
 
@@ -64,7 +64,7 @@ fun main() {
 
 </CodeGroup>
 
-# Adding dependencies
+## Adding dependencies
 
 You can add dependencies to your project by adding them to your `pom.xml` file.
 

--- a/docs/challenges/language-support/ocaml.mdx
+++ b/docs/challenges/language-support/ocaml.mdx
@@ -8,7 +8,7 @@ description: "Learn how to solve CodeCrafters challenges in OCaml"
   OCaml](https://ocaml.org/docs/tour-of-ocaml) to get up to speed.
 </Note>
 
-# Local development
+## Local development
 
 To run the code for your challenge locally, you'll need [opam](https://opam.ocaml.org/) and [dune](https://dune.build/install) installed. Our test runners use Dune v3.16 (as of September 2024).
 
@@ -21,12 +21,12 @@ dune build --build-dir /tmp/redis
 exec /tmp/redis/default/main.exe "$@"
 ```
 
-# File structure
+## File structure
 
 - The files for your solution are placed in the `src/` directory.
 - `src/main.ml` is the entry point for your OCaml program.
 
-# Adding more files
+## Adding more files
 
 You can organize your code by adding more `.ml` files in the `src/` directory. The test runner will include them when building and running your code.
 
@@ -44,7 +44,7 @@ let bar () = Printf.printf "Hello World!\n"
 
 </CodeGroup>
 
-# Adding dependencies
+## Adding dependencies
 
 If you're looking for OCaml libraries, you can browse the [opam package repository](https://opam.ocaml.org/packages/).
 
@@ -75,7 +75,7 @@ If you're looking for OCaml libraries, you can browse the [opam package reposito
     <Info>For more details, check the OCaml documentation on [Adding a Dependency](https://ocaml.org/docs/managing-dependencies#adding-a-dependency-to-your-dune-project-file).</Info>
 
   </Step>
-  
+
   <Step title="Install dependencies">
     You need to regenerate the `.opam` file from `dune-project` before installing dependencies.
 
@@ -85,7 +85,7 @@ If you're looking for OCaml libraries, you can browse the [opam package reposito
     dune build
     ```
 
-    <Note>If you’ve already used the library in an `.ml` file, `dune build` will exit with an error. This is okay — it’ll still update the `.opam` file (required for the next step).</Note>
+    <Note>If you've already used the library in an `.ml` file, `dune build` will exit with an error. This is okay — it'll still update the `.opam` file (required for the next step).</Note>
 
     Then, run this command to install the dependencies:
 

--- a/docs/challenges/language-support/python.mdx
+++ b/docs/challenges/language-support/python.mdx
@@ -8,7 +8,7 @@ description: "Learn how to solve CodeCrafters challenges in Python"
   Python](https://automatetheboringstuff.com/) to get up to speed.
 </Note>
 
-# Local development
+## Local development
 
 To run the code for your challenge locally, you'll need `python3` installed. Our test runners use version `3.12` (as of April 2024).
 
@@ -20,12 +20,12 @@ The script for your challenge (like `./spawn_redis_server.sh`) will run your cod
 exec python3 -m app.main "$@"
 ```
 
-# File structure
+## File structure
 
 - The files for your solution are placed in the `app/` directory.
 - `app/main.py` contains the `main` function, which is what the test runner executes.
 
-# Adding more files
+## Adding more files
 
 You can add more files and directories to `app/`. The test runner will include them when compiling your code.
 
@@ -48,7 +48,7 @@ def foo():
 
 </CodeGroup>
 
-# Adding dependencies
+## Adding dependencies
 
 <Note>
   Not all challenges support managing dependencies via Pipenv at the moment.
@@ -78,4 +78,4 @@ This will create a virtual environment (if it doesn't exist) and add the followi
 requests = "*"
 ```
 
-It’ll also make changes to your `Pipfile.lock`.
+It'll also make changes to your `Pipfile.lock`.

--- a/docs/challenges/language-support/ruby.mdx
+++ b/docs/challenges/language-support/ruby.mdx
@@ -5,7 +5,7 @@ description: "Learn how to solve CodeCrafters challenges in Ruby"
 
 <Note> **New to Ruby?** We recommend [Ruby in Twenty Minutes](https://www.ruby-lang.org/en/documentation/quickstart/) to get up to speed.</Note>
 
-# Local development
+## Local development
 
 To run the code for your challenge locally, you'll need `ruby` installed. Our test runners use version `3.3` (as of May 2024).
 
@@ -17,12 +17,12 @@ The script for your challenge (like `./spawn_redis_server.sh`) will run your cod
 exec bundle exec ruby app/main.rb "$@"
 ```
 
-# File structure
+## File structure
 
 - The files for your solution are placed in the `app/` directory.
 - `app/main.rb` is the entrypoint of the project.
 
-# Adding more files
+## Adding more files
 
 You can add more files and directories to `app/`. The test runner will include them when compiling your code.
 
@@ -44,7 +44,7 @@ end
 
 </CodeGroup>
 
-# Adding dependencies
+## Adding dependencies
 
 `Gemfile` lists your project's dependencies. You can add dependencies by specifying the name of the gem and optionally the version.
 

--- a/docs/challenges/language-support/rust.mdx
+++ b/docs/challenges/language-support/rust.mdx
@@ -8,7 +8,7 @@ description: "Learn how to solve CodeCrafters challenges in Rust"
   Example](https://doc.rust-lang.org/rust-by-example/) to get up to speed.
 </Note>
 
-# Local development
+## Local development
 
 To run the code for your challenge locally, you'll need `cargo` installed. Our test runners use version `1.76` (as of April 2024).
 
@@ -25,12 +25,12 @@ exec cargo run \
     --manifest-path $(dirname "$0")/Cargo.toml -- "$@"
 ```
 
-# File structure
+## File structure
 
 - The files for your solution are placed in the `src` directory.
 - `src/main.rs` contains the `main` function, which is what the test runner executes.
 
-# Adding more files
+## Adding more files
 
 You can add more files and directories to the `src` directory. The test runner will include them when compiling your code.
 
@@ -62,7 +62,7 @@ pub fn foo() {
 
 Refer to the Rust [documentation](https://doc.rust-lang.org/book/ch07-05-separating-modules-into-different-files.html) for more details.
 
-# Adding dependencies
+## Adding dependencies
 
 You can add dependencies to your program using `cargo add`.
 

--- a/docs/challenges/language-support/typescript.mdx
+++ b/docs/challenges/language-support/typescript.mdx
@@ -3,7 +3,7 @@ title: "TypeScript"
 description: "Learn how to solve CodeCrafters challenges in TypeScript"
 ---
 
-# Local development
+## Local development
 
 To run the code for your challenge locally, you'll need `bun` [installed](https://bun.sh/docs/installation). Our test runners use Bun v1.1 (as of May 2024).
 
@@ -16,12 +16,12 @@ look something like this:
 exec bun run app/main.ts "$@"
 ```
 
-# File structure
+## File structure
 
 - The files for your solution are placed in the `app/` directory.
 - `app/main.ts` is the entrypoint for the program.
 
-# Adding more files
+## Adding more files
 
 You can add more files and directories to `app/`. The test runner will include them when compiling your code.
 
@@ -57,7 +57,7 @@ Refer to the Bun [documentation](https://bun.sh/docs/runtime/modules) for additi
   to export.
 </Note>
 
-# Adding dependencies
+## Adding dependencies
 
 You can add dependencies to your project using `bun add`.
 

--- a/docs/challenges/language-support/zig.mdx
+++ b/docs/challenges/language-support/zig.mdx
@@ -8,7 +8,7 @@ description: "Learn how to solve CodeCrafters challenges in Zig"
   [ziglang.org/learn](https://ziglang.org/learn/) to get up to speed.
 </Note>
 
-# Local development
+## Local development
 
 To run the code for your challenge locally, you'll need `zig` installed. Our test runners use version `0.11` (as of November 2023).
 
@@ -23,12 +23,12 @@ zig build-exe ./app/main.zig
 exec ./main "$@"
 ```
 
-# File structure
+## File structure
 
 - The files for your solution are placed in the `app` directory.
 - `app/main.zig` contains the `main` function, which is what the test runner executes.
 
-# Adding more files
+## Adding more files
 
 You can add more files and directories to the `app` directory. The test runner will include them when compiling your code.
 
@@ -76,7 +76,7 @@ pub fn main() void {
 
 </CodeGroup>
 
-# Adding dependencies
+## Adding dependencies
 
 We don't support the package manager added in Zig 0.11 yet. For now, you'll need to copy in any dependencies you need into your project
 and import them using `@import`.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated documentation headers across multiple language support files from single-level (`#`) to second-level (`##`) headings
	- Improved document structure and readability for language challenge guides
	- No changes to actual content or functionality of the documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->