### PR TITLE
Add warning about potential data loss when publishing to GitHub

### DIFF
--- a/docs/features/publish-to-github.mdx
+++ b/docs/features/publish-to-github.mdx
@@ -13,14 +13,17 @@ Each CodeCrafters Challenge includes an option in the language dropdown menu to 
 
 Once you click 'Publish,' any subsequent changes made to the `master` branch of your CodeCrafters repository will automatically sync to GitHub.
 
-<Warning>
-  This synchronization can overwrite the selected GitHub repository.  
-  We strongly recommend NOT making changes directly to the synced GitHub repository to avoid accidental data loss.
-</Warning>
-
 <Note>
-  This synchronization is *one-way* – changes made to the GitHub repository will NOT sync back to your CodeCrafters repository.
+  <p>Don't push changes to your GitHub repository directly.</p>
+  <p>
+    Push to your CodeCrafters Git repository instead, and we'll sync changes to
+    GitHub.
+  </p>
 </Note>
+
+<Warning>
+  Any changes pushed to your GitHub repository directly will be overridden.
+</Warning>
 
 ## Frequently Asked Questions
 
@@ -34,7 +37,7 @@ Your GitHub repository will remain unchanged.
 
 ### What happens if I push changes directly to my GitHub repository instead of my CodeCrafters repository?
 
-It will have no effect on the CodeCrafters repository. As mentioned in the callout above, syncing is one-way only. 
+It will have no effect on the CodeCrafters repository. As mentioned in the callout above, syncing is one-way only.
 
 ### Who can see my published repository?
 


### PR DESCRIPTION
Context:

https://forum.codecrafters.io/t/readme-commit-deleted-after-cloning/14270/8

Preview:

<img width="1568" height="808" alt="image" src="https://github.com/user-attachments/assets/49cfe285-c507-4b77-b9ae-eddf78787512" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Clarifies one-way sync by adding guidance to push only to CodeCrafters and a warning that direct GitHub pushes will be overridden.
> 
> - **Docs (`docs/features/publish-to-github.mdx`)**:
>   - Add explicit guidance in `Note` to avoid pushing directly to GitHub and to push to the CodeCrafters repository instead.
>   - Add `Warning` stating that direct pushes to GitHub will be overridden.
>   - Minor formatting cleanup in FAQ.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8de0211c6973a3fa50b149b21235713a9c94a092. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->